### PR TITLE
Fix validate format for non string parameters

### DIFF
--- a/pvoutput/base.py
+++ b/pvoutput/base.py
@@ -64,7 +64,7 @@ class PVOutputBase:
         """handles the regular expression format checks"""
         try:
             compiled = re.compile(format_string)
-            match = compiled.match(value)
+            match = compiled.match(str(value))
             if match is None:
                 raise ValueError(f"key '{key}', with value '{value}' does not match '{format_string!r}'")
         except re.error as error:


### PR DESCRIPTION
Currently, the regEx validator fails when c1 flag is set 1, as the match function requires string as input type.
Converting the value to string fixes this issue.